### PR TITLE
Fix environment variables loading too late

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Jippity sends messages to all connected websockets, so a tool like [Insomnia](ht
 
 ## Configuration Using Environment Variables
 This tool is configured exclusively with environment variables.
-Environment variables will be loaded from the `.env` file in the root of this repository, if present.
+Environment variables will be loaded from the `.env` file in the backend folder, if present.
 A config file may be added in the future.
 
 | Environment Variable  | Description                                                                                                                                     | Required | Example       |

--- a/backend/src/api-types.ts
+++ b/backend/src/api-types.ts
@@ -370,26 +370,26 @@ const ActionMessageSchema: JSONSchemaType<ActionMessage> = {
 };
 
 type MessageTypeMapping = {
-    "startup": StartupMessage;
-    "context": ContextMessage;
+    startup: StartupMessage;
+    context: ContextMessage;
     "actions/register": RegisterActionsMessage;
     "actions/unregister": UnregisterActionsMessage;
     "actions/force": ForceActionMessage;
     "action/result": ActionResultMessage;
-    "action": ActionMessage;
+    action: ActionMessage;
 };
 
 type MessageType = keyof MessageTypeMapping;
 
 /** Validators */
 export const Validators: Record<MessageType, ValidateFunction<BaseMessage>> = {
-    "startup": ajv.compile(StartupMessageSchema),
-    "context": ajv.compile(ContextMessageSchema),
+    startup: ajv.compile(StartupMessageSchema),
+    context: ajv.compile(ContextMessageSchema),
     "actions/register": ajv.compile(RegisterActionsMessageSchema),
     "actions/unregister": ajv.compile(UnregisterActionsMessageSchema),
     "actions/force": ajv.compile(ForceActionMessageSchema),
     "action/result": ajv.compile(ActionResultMessageSchema),
-    "action": ajv.compile(ActionMessageSchema)
+    action: ajv.compile(ActionMessageSchema)
 };
 
 function validateAndCast<T extends keyof MessageTypeMapping>(
@@ -401,7 +401,11 @@ function validateAndCast<T extends keyof MessageTypeMapping>(
         return ok(obj as MessageTypeMapping[T]);
     }
     // logValidationErrors(validator);
-    return err(new MessageDeserializationError(`Validation of command "${command}" failed: ${ajv.errorsText(validator.errors)}`));
+    return err(
+        new MessageDeserializationError(
+            `Validation of command "${command}" failed: ${ajv.errorsText(validator.errors)}`
+        )
+    );
 }
 
 /**
@@ -414,11 +418,13 @@ export function deserializeMessage(json: string): Result<Message, MessageDeseria
     try {
         obj = JSON.parse(json);
     } catch (e) {
-        return err(new MessageDeserializationError("Message is not valid JSON", errorOrUndefined(e)));
+        return err(
+            new MessageDeserializationError("Message is not valid JSON", errorOrUndefined(e))
+        );
     }
 
     if (!obj.command) {
-        return err(new MessageDeserializationError("Message is missing the \"command\" property"));
+        return err(new MessageDeserializationError('Message is missing the "command" property'));
     }
 
     if (!(obj.command in Validators)) {
@@ -438,7 +444,12 @@ export function validateActionSchema(action: Action): Result<null, MessageDeseri
     }
     if (!ajv.validateSchema(action.schema) as boolean) {
         const errorMessage = ajv.errorsText() ?? "Unknown error";
-        return err(new MessageDeserializationError("Invalid Action schema", new MessageDeserializationError(errorMessage)));
+        return err(
+            new MessageDeserializationError(
+                "Invalid Action schema",
+                new MessageDeserializationError(errorMessage)
+            )
+        );
     }
     return ok(null);
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,3 +1,6 @@
+// Load environment variables from .env file
+import "dotenv/config";
+
 import { RawData, WebSocket, WebSocketServer } from "ws";
 import util from "util";
 import assert from "node:assert";
@@ -7,8 +10,6 @@ import { log } from "./logging";
 import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import { JippityHandler } from "./jippity-handler";
 
-// Load environment variables from .env file
-import "dotenv/config";
 import { sleep } from "./utils";
 
 // ***************************

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -111,7 +111,7 @@ wss.on("connection", (ws) => {
  */
 export function send(message: Message) {
     assert(wsConnections, "send called with wsConnections uninitialized");
-    assert(message.command, "Messages must always have a \"command\" property");
+    assert(message.command, 'Messages must always have a "command" property');
 
     if (wsConnections.length == 0) {
         log.warn("send function called with no active WebSocket connections");

--- a/backend/src/jippity-handler.ts
+++ b/backend/src/jippity-handler.ts
@@ -2,7 +2,8 @@ import {
     Action,
     ActionMessage,
     ActionResultMessage,
-    deserializeMessage, ForceActionMessage,
+    deserializeMessage,
+    ForceActionMessage,
     Message,
     validateActionSchema
 } from "./api-types";
@@ -87,7 +88,7 @@ export class JippityHandler {
                     );
                     log.info(`Jippity says: ${content}`);
                     // this.openaiRequestInProgress = false;
-                    this.state = { id: "state/idle" }
+                    this.state = { id: "state/idle" };
                     return;
                 } else if (choice.finish_reason === "tool_calls") {
                     let toolCalls = choice.message.tool_calls;
@@ -169,7 +170,9 @@ export class JippityHandler {
                 this.handleMessage(message);
                 break;
             default:
-                log.debug(`Added message with "${message.command}" command to message queue (current state is ${this.state.id})`)
+                log.debug(
+                    `Added message with "${message.command}" command to message queue (current state is ${this.state.id})`
+                );
                 this.messageQueue.offer(message);
                 break;
         }

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -61,5 +61,5 @@ export function convertForcedActionMessageToOpenAIMessage(
     return {
         role: "user",
         content: content
-    }
+    };
 }


### PR DESCRIPTION
`dotenv/config` was imported after `./logging`, so the `LOG_LEVEL` environment variable was not loaded before the log level was set, so I moved the import to the top. I also updated the `.env` file location in the README.

All other changes are from `npm run format`, so I put them in a separate commit.